### PR TITLE
strip spaces and newlines from gene and annotation lines

### DIFF
--- a/scvr/scvr/converters.py
+++ b/scvr/scvr/converters.py
@@ -197,12 +197,14 @@ def output_seurat_cells(adata,ann_list,reportdir='./seurat_report',gene_list=Non
     ann_list = list(dict.fromkeys(ann_list))
     ### make sure all labels exist
     for ann in ann_list:
+        ann = ann.strip(" ").strip("\n")
         if ann not in adata.obs.columns:
             raise ValueError('could not find %s in %s'  % (ann,adata.obs.columns))
     if(gene_list is not None):
         ###remove duplicate keys
         gene_list = list(dict.fromkeys(gene_list)) 
         for gene in gene_list:
+            gene = gene.strip(" ").strip("\n")
             if(gene not in adata.var_names):
                 raise ValueError('could not find %s in `adata.var_names`'  % (gene))
     try:


### PR DESCRIPTION
I copied some gene names into a text file and didn't notice the spaces at the end of the lines. Resulted in the converter not being able to find the gene names and took me a little while to figure out why. If we merge this it might be a little easier for users, otherwise maybe we could add a warning like "Watch out for spaces after gene names..." or something like that